### PR TITLE
Set up vagrant for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # files to avoid checking into git
 *.DS_STORE
 *.pyc
+
+# Do not track Vagrant dotfiles
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,66 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    #vb.gui = true
+    # Customize the amount of memory on the VM:
+    vb.memory = "1024"
+    vb.cpus = 1
+  end
+
+  # Copy your .gitconfig file so that your credentials are correct
+  config.vm.provision "file", source: "~/.gitconfig", destination: "~/.gitconfig"
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+
+  ######################################################################
+  # Add Python Flask environment
+  ######################################################################
+  # Forward Python Flask port
+  config.vm.network :forwarded_port, guest: 5000, host: 5000, auto_correct: true
+
+  # Setup a Python development environment
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y git python-pip python-dev build-essential
+    sudo apt-get -y autoremove
+  SHELL
+
+end


### PR DESCRIPTION
The Vagrantfile is simply a revision of the template provided in class, so they're similar aside from a few details (i.e., we aren't using Redis yet so I removed that part for now; we may end up with a different DB altogether anyway).

I wanted to complete this ASAP so that we would all have a unified local dev environment.
Please download this feature branch and manually test to verify that the Vagrantfile works:

```
# if you have a vagrant instance running already, make sure to do vagrant halt
# in the appropriate directory
vagrant halt
# main instructions
git pull
git checkout origin/feature/Set-up-vagrant-for-local-dev
# make sure you're in the same directory as Vagrantfile
vagrant up
vagrant ssh
# optional - check to see that Python 2.7.6 is installed
python --version
exit
```

This PR also adds `.vagrant` to the gitignore file, mirroring the set up that the professor has in the Flask demo repo.

 