### PR TITLE
Refactor items to have different ids

### DIFF
--- a/persistence/persistence.py
+++ b/persistence/persistence.py
@@ -276,14 +276,12 @@ class DatabaseEngine(object):
 
             elif modified_item_index is not None:
                 # much easier this way
-                print 'test'
                 try:
                     for key in kwargs:
                         if key in DatabaseEngine.UPDATABLE_ITEM_FIELDS:
                             self._wishlist_resources[wishlist_id]['items'][modified_item_index][key] = kwargs.get(key)
                     return json.dumps(self._wishlist_resources[wishlist_id]['items'][modified_item_index], indent=4)
                 except IndexError as e:
-                    print str(e)
                     raise ItemNotFoundException
 
         else:

--- a/wishlists.py
+++ b/wishlists.py
@@ -99,7 +99,7 @@ def read_wishlist_item_by_id(wishlist_id, item_id):
     """
     
     try:
-        item = db.retrieve_item(wishlist_id, item_id)
+        item = db.retrieve_item(wishlist_id, item_id=item_id)
         return item, HTTP_200_OK
     except ItemException:
         return jsonify(message='Item with id %s could not be found' % item_id), HTTP_404_NOT_FOUND
@@ -113,7 +113,7 @@ def read_wishlist_item_by_index(wishlist_id, item_index):
     """
     
     try:
-        item = db.retrieve_item(wishlist_id, item_id)
+        item = db.retrieve_item(wishlist_id, item_index=item_index)
         return item, HTTP_200_OK
     except ItemException:
         return jsonify(message='Item with id %s could not be found' % item_id), HTTP_404_NOT_FOUND

--- a/wishlists.py
+++ b/wishlists.py
@@ -52,7 +52,6 @@ def add_item_to_wishlist(wishlist_id):
     tempDic['description'] = request.json['description']
     try:
         add_item_response = db.add_item(wishlist_id, tempDic)
-        print add_item_response
         return add_item_response, HTTP_201_CREATED
     except WishlistException:
         return jsonify(message='Cannot add a new item %s' % request.json['item_id']), HTTP_400_BAD_REQUEST

--- a/wishlists.py
+++ b/wishlists.py
@@ -134,14 +134,15 @@ def update_wishlist(id):
         return jsonify(message), HTTP_404_NOT_FOUND
 
 @app.route('/wishlists/<int:wishlist_id>/items/<string:item_id>', methods=['PUT'])
-def update_wishlist_item(wishlist_id, item_id):
+def update_wishlist_item_by_id(wishlist_id, item_id):
     """
     The route for modifying the description of an item in a specific wishlist.
+    Accepts a str id for the item_id.
     """
 
     try:
         data = request.get_json()
-        return db.update_wishlist_item(wishlist_id, item_id, **data ), HTTP_200_OK
+        return db.update_wishlist_item(wishlist_id, item_id=item_id, **data ), HTTP_200_OK
     except WishlistException:
         message = { 'error' : 'Wishlist %s was not found' % wishlist_id }
         return jsonify(message), HTTP_404_NOT_FOUND
@@ -149,21 +150,52 @@ def update_wishlist_item(wishlist_id, item_id):
         message = { 'error' : 'Item %s was not found' % item_id }
         return jsonify(message), HTTP_404_NOT_FOUND
 
+@app.route('/wishlists/<int:wishlist_id>/items/<int:item_index>', methods=['PUT'])
+def update_wishlist_item_by_index(wishlist_id, item_index):
+    """
+    The route for modifying the description of an item in a specific wishlist.
+    Accepts an int for the item's index.
+    """
+
+    try:
+        data = request.get_json()
+        return db.update_wishlist_item(wishlist_id, item_index=item_index, **data ), HTTP_200_OK
+    except WishlistException:
+        message = { 'error' : 'Wishlist %s was not found' % wishlist_id }
+        return jsonify(message), HTTP_404_NOT_FOUND
+    except ItemException:
+        message = { 'error' : 'Item with index %s was not found' % item_index }
+        return jsonify(message), HTTP_404_NOT_FOUND
+
 @app.route('/wishlists/<int:wishlist_id>/items/<string:item_id>', methods=['DELETE'])
-def remove_wishlist_item(wishlist_id, item_id):
+def remove_wishlist_item_by_id(wishlist_id, item_id):
     """
     The route for removing a specific item in a wishlist,
     given a wishlist_id and the item_id
     """
     
     try:
-        db.remove_item(wishlist_id, item_id)
+        db.remove_item(wishlist_id, item_id=item_id)
         return '', HTTP_204_NO_CONTENT
     except ItemException:
         return jsonify(message='Item with id %s could not be found' % item_id), HTTP_404_NOT_FOUND
     except WishlistException:
         return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND      
 
+@app.route('/wishlists/<int:wishlist_id>/items/<int:item_index>', methods=['DELETE'])
+def remove_wishlist_item_by_index(wishlist_id, item_index):
+    """
+    The route for removing a specific item in a wishlist,
+    given a wishlist_id and the item_id
+    """
+    
+    try:
+        db.remove_item(wishlist_id, item_index=item_index)
+        return '', HTTP_204_NO_CONTENT
+    except ItemException:
+        return jsonify(message='Item with id %s could not be found' % item_index), HTTP_404_NOT_FOUND
+    except WishlistException:
+        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND      
 
 if __name__ == '__main__':
 

--- a/wishlists.py
+++ b/wishlists.py
@@ -93,7 +93,21 @@ def item(wishlist_id):
             return jsonify(message='Could not find a wishlist with id %s' % wishlist_id), HTTP_404_NOT_FOUND
 
 @app.route('/wishlists/<int:wishlist_id>/items/<string:item_id>', methods=['GET'])
-def read_wishlist_item(wishlist_id, item_id):
+def read_wishlist_item_by_id(wishlist_id, item_id):
+    """
+    The route for retrieving a specific item in a wishlist.
+    """
+    
+    try:
+        item = db.retrieve_item(wishlist_id, item_id)
+        return item, HTTP_200_OK
+    except ItemException:
+        return jsonify(message='Item with id %s could not be found' % item_id), HTTP_404_NOT_FOUND
+    except WishlistException:
+        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND      
+
+@app.route('/wishlists/<int:wishlist_id>/items/<int:item_index>', methods=['GET'])
+def read_wishlist_item_by_index(wishlist_id, item_index):
     """
     The route for retrieving a specific item in a wishlist.
     """

--- a/wishlists.py
+++ b/wishlists.py
@@ -17,7 +17,6 @@ HTTP_400_BAD_REQUEST = 400
 HTTP_404_NOT_FOUND = 404
 HTTP_409_CONFLICT = 409
 
-#db.create_wishlist('jesse','test')
 
 @app.route('/')
 def index():
@@ -27,35 +26,36 @@ def index():
 
 @app.route('/wishlists',methods=['POST'])
 def add_wishlist():
-	"""
-	The route for adding new wishlists, specified by userID and name of the wishlist. You can check 
-	the POST requests using CURL.
-	Example: curl -i -H 'Content-Type: application/json' -X POST -d '{"name":"Xynazog","user_id":123}' http://127.0.0.1:5000/wishlists
-	H is for headers, X is used to specify HTTP Method, d is used to pass a message.
-	"""
+    """
+    The route for adding new wishlists, specified by userID and name of the wishlist. You can check
+    the POST requests using CURL.
+    Example: curl -i -H 'Content-Type: application/json' -X POST -d '{"name":"Xynazog","user_id":123}' http://127.0.0.1:5000/wishlists
+    H is for headers, X is used to specify HTTP Method, d is used to pass a message.
+    """
     
-	name = request.json['name']
-	uid = request.json['user_id']
-	try:
-		return db.create_wishlist(name,uid), HTTP_200_OK
-	except WishlistException:
-		return jsonify(message='Cannot create a new wishlist named %s' % name), HTTP_400_BAD_REQUEST
+    name = request.json['name']
+    uid = request.json['user_id']
+    try:
+        return db.create_wishlist(name,uid), HTTP_200_OK
+    except WishlistException:
+        return jsonify(message='Cannot create a new wishlist named %s' % name), HTTP_400_BAD_REQUEST
 
 @app.route('/wishlists/<int:wishlist_id>/items',methods=['POST'])
 def add_item_to_wishlist(wishlist_id):
-	"""
-	The route for adding new items to the wishlist. This method can also be checked using CURL.
-	Pre-requisite: Create a wishlist to add an item.
-	Example: curl -i -H 'Content-Type: application/json' -X POST -d '{"id":"i123","description":"Awesome product!"}' http://127.0.0.1:5000/wishlists/1/items
-	"""
-    
-	tempDic = {}
-	tempDic['id'] = request.json['id']
-	tempDic['description'] = request.json['description']
-	try:
-		return db.add_item(wishlist_id,tempDic), HTTP_200_OK
-	except WishlistException:
-		return jsonify(message='Cannot add a new item %s' % request.json['id']), HTTP_400_BAD_REQUEST
+    """
+    The route for adding new items to the wishlist. This method can also be checked using CURL.
+    Pre-requisite: Create a wishlist to add an item.
+    Example: curl -i -H 'Content-Type: application/json' -X POST -d '{"id":"i123","description":"Awesome product!"}' http://127.0.0.1:5000/wishlists/1/items
+    """
+    tempDic = {}
+    tempDic['item_id'] = request.json['item_id']
+    tempDic['description'] = request.json['description']
+    try:
+        add_item_response = db.add_item(wishlist_id, tempDic)
+        print add_item_response
+        return add_item_response, HTTP_201_CREATED
+    except WishlistException:
+        return jsonify(message='Cannot add a new item %s' % request.json['item_id']), HTTP_400_BAD_REQUEST
 
 @app.route('/wishlists', methods=['GET'])
 def wishlists():
@@ -92,33 +92,34 @@ def item(wishlist_id):
         except WishlistException:
             return jsonify(message='Could not find a wishlist with id %s' % wishlist_id), HTTP_404_NOT_FOUND
 
+@app.route('/wishlists/<int:wishlist_id>/items/<int:item_index>', methods=['GET'])
+def read_wishlist_item_by_index(wishlist_id, item_index):
+    """
+    The route for retrieving a specific item in a wishlist.
+    """
+
+    try:
+        # the internal index is 1 less - this is true for all methods that accept an item_index
+        item = db.retrieve_item(wishlist_id, item_index=item_index - 1)
+        return item, HTTP_200_OK
+    except ItemException:
+        return jsonify(message='Item with id %s could not be found' % item_index), HTTP_404_NOT_FOUND
+    except WishlistException:
+        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND
+
 @app.route('/wishlists/<int:wishlist_id>/items/<string:item_id>', methods=['GET'])
 def read_wishlist_item_by_id(wishlist_id, item_id):
     """
     The route for retrieving a specific item in a wishlist.
     """
-    
+
     try:
         item = db.retrieve_item(wishlist_id, item_id=item_id)
         return item, HTTP_200_OK
     except ItemException:
         return jsonify(message='Item with id %s could not be found' % item_id), HTTP_404_NOT_FOUND
     except WishlistException:
-        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND      
-
-@app.route('/wishlists/<int:wishlist_id>/items/<int:item_index>', methods=['GET'])
-def read_wishlist_item_by_index(wishlist_id, item_index):
-    """
-    The route for retrieving a specific item in a wishlist.
-    """
-    
-    try:
-        item = db.retrieve_item(wishlist_id, item_index=item_index)
-        return item, HTTP_200_OK
-    except ItemException:
-        return jsonify(message='Item with id %s could not be found' % item_id), HTTP_404_NOT_FOUND
-    except WishlistException:
-        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND      
+        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND
 
 @app.route('/wishlists/<int:id>', methods=['PUT'])
 def update_wishlist(id):
@@ -133,23 +134,6 @@ def update_wishlist(id):
         message = { 'error' : 'Wishlist %s was not found' % id }
         return jsonify(message), HTTP_404_NOT_FOUND
 
-@app.route('/wishlists/<int:wishlist_id>/items/<string:item_id>', methods=['PUT'])
-def update_wishlist_item_by_id(wishlist_id, item_id):
-    """
-    The route for modifying the description of an item in a specific wishlist.
-    Accepts a str id for the item_id.
-    """
-
-    try:
-        data = request.get_json()
-        return db.update_wishlist_item(wishlist_id, item_id=item_id, **data ), HTTP_200_OK
-    except WishlistException:
-        message = { 'error' : 'Wishlist %s was not found' % wishlist_id }
-        return jsonify(message), HTTP_404_NOT_FOUND
-    except ItemException:
-        message = { 'error' : 'Item %s was not found' % item_id }
-        return jsonify(message), HTTP_404_NOT_FOUND
-
 @app.route('/wishlists/<int:wishlist_id>/items/<int:item_index>', methods=['PUT'])
 def update_wishlist_item_by_index(wishlist_id, item_index):
     """
@@ -159,7 +143,7 @@ def update_wishlist_item_by_index(wishlist_id, item_index):
 
     try:
         data = request.get_json()
-        return db.update_wishlist_item(wishlist_id, item_index=item_index, **data ), HTTP_200_OK
+        return db.update_wishlist_item(wishlist_id, modified_item_index=item_index - 1, **data), HTTP_200_OK
     except WishlistException:
         message = { 'error' : 'Wishlist %s was not found' % wishlist_id }
         return jsonify(message), HTTP_404_NOT_FOUND
@@ -167,20 +151,22 @@ def update_wishlist_item_by_index(wishlist_id, item_index):
         message = { 'error' : 'Item with index %s was not found' % item_index }
         return jsonify(message), HTTP_404_NOT_FOUND
 
-@app.route('/wishlists/<int:wishlist_id>/items/<string:item_id>', methods=['DELETE'])
-def remove_wishlist_item_by_id(wishlist_id, item_id):
+@app.route('/wishlists/<int:wishlist_id>/items/<string:item_id>', methods=['PUT'])
+def update_wishlist_item_by_id(wishlist_id, item_id):
     """
-    The route for removing a specific item in a wishlist,
-    given a wishlist_id and the item_id
+    The route for modifying the description of an item in a specific wishlist.
+    Accepts a str id for the item_id.
     """
-    
+
     try:
-        db.remove_item(wishlist_id, item_id=item_id)
-        return '', HTTP_204_NO_CONTENT
-    except ItemException:
-        return jsonify(message='Item with id %s could not be found' % item_id), HTTP_404_NOT_FOUND
+        data = request.get_json()
+        return db.update_wishlist_item(wishlist_id, modified_item_id=item_id, **data ), HTTP_200_OK
     except WishlistException:
-        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND      
+        message = { 'error' : 'Wishlist %s was not found' % wishlist_id }
+        return jsonify(message), HTTP_404_NOT_FOUND
+    except ItemException:
+        message = { 'error' : 'Item %s was not found' % item_id }
+        return jsonify(message), HTTP_404_NOT_FOUND
 
 @app.route('/wishlists/<int:wishlist_id>/items/<int:item_index>', methods=['DELETE'])
 def remove_wishlist_item_by_index(wishlist_id, item_index):
@@ -188,19 +174,34 @@ def remove_wishlist_item_by_index(wishlist_id, item_index):
     The route for removing a specific item in a wishlist,
     given a wishlist_id and the item_id
     """
-    
+
     try:
-        db.remove_item(wishlist_id, item_index=item_index)
+        db.remove_item(wishlist_id, item_index=item_index - 1)
         return '', HTTP_204_NO_CONTENT
     except ItemException:
         return jsonify(message='Item with id %s could not be found' % item_index), HTTP_404_NOT_FOUND
     except WishlistException:
-        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND      
+        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND
+
+@app.route('/wishlists/<int:wishlist_id>/items/<string:item_id>', methods=['DELETE'])
+def remove_wishlist_item_by_id(wishlist_id, item_id):
+    """
+    The route for removing a specific item in a wishlist,
+    given a wishlist_id and the item_id
+    """
+
+    try:
+        db.remove_item(wishlist_id, item_id=item_id)
+        return '', HTTP_204_NO_CONTENT
+    except ItemException:
+        return jsonify(message='Item with id %s could not be found' % item_id), HTTP_404_NOT_FOUND
+    except WishlistException:
+        return jsonify(message='Wishlist with id %d could not be found' % wishlist_id), HTTP_404_NOT_FOUND
 
 if __name__ == '__main__':
 
     # Pull options from environment
     debug = os.getenv('DEBUG', 'False') == 'True'
     port = os.getenv('PORT', '5000')
-	
+
     app.run(host='0.0.0.0', port=int(port), debug=debug)


### PR DESCRIPTION
This PR allows us to use a numeric id for all items endpoints.

Note the following:
- There is a slight bug wherein passing in 0 and 1 results in getting the first item; this is because Python lists' indices can be negative, so when the passed in index of 0 is adjusted internally (i.e., passed_index - 1), we get items[-1].  This translates to "get the last item", which technically works.  This is acceptable tech debt for now since this whole system will be overhauled when we have a proper id.
- I have done some manual testing with the endpoints to ensure that they work - please do the same if possible.
- Using `items/<item_id>` is something we should remove in the future and replace with `/items?item_id=x`.  That way we can reduce the amount of route clutter in `wishlists.py`.